### PR TITLE
Support for Distant Horizons rendering on Multiverse servers

### DIFF
--- a/shaders/dimension.properties
+++ b/shaders/dimension.properties
@@ -1,3 +1,3 @@
-dimension.world0 = minecraft:overworld
-dimension.world-1 = minecraft:the_nether
-dimension.world1 = minecraft:the_end
+dimension.world0 = *
+dimension.world-1 = minecraft:the_nether minecraft:nether
+dimension.world1 = minecraft:the_end minecraft:end


### PR DESCRIPTION
Assigns overworld dimension to all worlds but the_nether and the_end.
I found that MakeUp Ultra Fast was not rendering Distant Horizons LODs on additional worlds on my server.
I "borrowed" this from some other shader that did not have that problem and it fixed it.

Maybe this is worth a consideration to be merged upstream. I have no experience with Minecraft shader development whatsoever so this could have side effects i did not consider. 